### PR TITLE
Store artifact and separate build job

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -13,8 +13,8 @@ on:
       - "**" # never deploy for tags
 
 jobs:
-  deploy:
-    name: Deploy
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
@@ -76,6 +76,24 @@ jobs:
         run: npm run build
         env:
           PATH_PREFIX: ${{ steps.delivery-path-prefix.outputs.result }}
+
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: ./build
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Download build
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: ./build
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
This proposal will separate the build and deploy jobs, using an artifact to pass the files. It is an incremental first step towards eventually integrating validation steps (hyperlink checks, lighthouse scores) in the middle.